### PR TITLE
Add interface for API response

### DIFF
--- a/interface/homeWork.ts
+++ b/interface/homeWork.ts
@@ -54,10 +54,10 @@ type IApiResponse = IApiResponseSuccess | IApiResponseError;
 
 
 // Added a restriction, now there will be an error if you use unrelated types of status and data
-const resp: IApiResponse<IErrorResponseData> = {
-    status: "success",
-    data: {
-        errorMessage: "",
-        errorCode: 1,
-    }
-}
+// const resp: IApiResponse<IErrorResponseData> = {
+//     status: "success",
+//     data: {
+//         errorMessage: "",
+//         errorCode: 1,
+//     }
+// }

--- a/interface/homeWork.ts
+++ b/interface/homeWork.ts
@@ -1,0 +1,49 @@
+/*{
+	"sum": 10000,
+	"from": 2,
+	"to": 4
+}
+
+// In case of success
+{
+	"status": "success",
+	"data": {
+		"databaseId": 567,
+		"sum": 10000,
+		"from": 2,
+		"to": 4
+	}
+},
+
+// In case of fail
+{
+	"status": "failed",
+	"data": {
+		"errorMessage": "Недостатньо коштів",
+		"errorCode": 4
+	}
+}
+ */
+
+interface IRequestPayload {
+    sum: number;
+    from: number;
+    to: number;
+}
+
+interface ISuccessResponseData extends IRequestPayload {
+    databaseId: number;
+}
+
+interface IErrorResponseData {
+    errorMessage: string;
+    errorCode: number;
+}
+
+interface IApiResponse<T> {
+    status: 'success' | 'failed';
+    data: T;
+}
+
+type SuccessResponse = IApiResponse<ISuccessResponseData>;
+type ErrorResponse = IApiResponse<IErrorResponseData>;

--- a/interface/homeWork.ts
+++ b/interface/homeWork.ts
@@ -40,10 +40,24 @@ interface IErrorResponseData {
     errorCode: number;
 }
 
-interface IApiResponse<T> {
-    status: 'success' | 'failed';
-    data: T;
+interface IApiResponseSuccess {
+    status: 'success';
+    data: ISuccessResponseData;
 }
 
-type SuccessResponse = IApiResponse<ISuccessResponseData>;
-type ErrorResponse = IApiResponse<IErrorResponseData>;
+interface IApiResponseError {
+    status: 'failed';
+    data: IErrorResponseData;
+}
+
+type IApiResponse = IApiResponseSuccess | IApiResponseError;
+
+
+// Added a restriction, now there will be an error if you use unrelated types of status and data
+const resp: IApiResponse<IErrorResponseData> = {
+    status: "success",
+    data: {
+        errorMessage: "",
+        errorCode: 1,
+    }
+}


### PR DESCRIPTION
Interface for API response added in homeWork.ts file. This commit includes request payload and both success and error responses with the status and data. It helps to establish a clear understanding of the shape and structure of the API responses and promotes Type safety for the API integration.