### PR TITLE
Add new types for deep readonly, require, and pick

### DIFF
--- a/comparison-of-types/index.ts
+++ b/comparison-of-types/index.ts
@@ -1,12 +1,11 @@
 // Task 1
 type DeepReadonly<T> = {
-    readonly [K in keyof T]: T[K] extends Record<string, unknown> ? DeepReadonly<T[K]> : T[K];
+    readonly [key in keyof T]: DeepReadonly<T[key]>
 }
 
 // Task 2
-type DeepRequireReadonly<T> = {
-    readonly [K in keyof Required<T>]: Required<T>[K] extends Record<string, unknown>
-        ? DeepRequireReadonly<Required<T>[K]>: Required<T>[K];
+type DeepRequiredReadonly<T> = {
+    readonly [key in keyof T]-?: DeepRequiredReadonly<T[key]>
 }
 
 // Task 3
@@ -26,6 +25,6 @@ interface User {
 }
 
 type MyReadonlyUser = DeepReadonly<User>;
-type MyDeepRequireReadonlyUser = DeepRequireReadonly<User>;
+type MyDeepRequireReadonlyUser = DeepRequiredReadonly<User>;
 type MyUpperCaseKeysUser = UpperCaseKeys<User>;
 type MyPickUser = TPick<User, 'name' | 'age'>;

--- a/comparison-of-types/index.ts
+++ b/comparison-of-types/index.ts
@@ -6,17 +6,19 @@ type DeepReadonly<T> = {
 // Task 2
 type DeepRequireReadonly<T> = {
     readonly [K in keyof Required<T>]: Required<T>[K] extends Record<string, unknown>
-        ? DeepRequireReadonly<Required<T>[K]> : Required<T>[K];
+        ? DeepRequireReadonly<Required<T>[K]>: Required<T>[K];
 }
 
 // Task 3
+type UpperCaseKeys<T> = {
+    [K in keyof T as Uppercase<string & K>]: T[K]
+}
 
 // Task 4
 type TPick<T, K extends keyof T> = {
     [P in K]: T[P];
 }
 
-// Testing for new types
 interface User {
     name: string;
     age: number;
@@ -25,4 +27,5 @@ interface User {
 
 type MyReadonlyUser = DeepReadonly<User>;
 type MyDeepRequireReadonlyUser = DeepRequireReadonly<User>;
+type MyUpperCaseKeysUser = UpperCaseKeys<User>;
 type MyPickUser = TPick<User, 'name' | 'age'>;

--- a/comparison-of-types/index.ts
+++ b/comparison-of-types/index.ts
@@ -1,0 +1,28 @@
+// Task 1
+type DeepReadonly<T> = {
+    readonly [K in keyof T]: T[K] extends Record<string, unknown> ? DeepReadonly<T[K]> : T[K];
+}
+
+// Task 2
+type DeepRequireReadonly<T> = {
+    readonly [K in keyof Required<T>]: Required<T>[K] extends Record<string, unknown>
+        ? DeepRequireReadonly<Required<T>[K]> : Required<T>[K];
+}
+
+// Task 3
+
+// Task 4
+type TPick<T, K extends keyof T> = {
+    [P in K]: T[P];
+}
+
+// Testing for new types
+interface User {
+    name: string;
+    age: number;
+    permission: string[];
+}
+
+type MyReadonlyUser = DeepReadonly<User>;
+type MyDeepRequireReadonlyUser = DeepRequireReadonly<User>;
+type MyPickUser = TPick<User, 'name' | 'age'>;


### PR DESCRIPTION
The commit contains three new type definitions in TypeScript for better type manipulation. The types comprise of deep readonly, require readonly, and a variant of a pick function. Test implementations were also given for these new types using a User interface.